### PR TITLE
Monkey patch support for 64 bit ints

### DIFF
--- a/src/types/array/index.js
+++ b/src/types/array/index.js
@@ -1,5 +1,6 @@
 const { MappingBaseType } = require("../base");
 const { isObjectType, isArray, isReferenceArray } = require("../util");
+const { propsToMapping } = require("../../props-to-mapping")
 
 function toArray(obj) {
   return isArray(obj.type) && MappingArray.create(obj).convert();
@@ -18,7 +19,14 @@ class MappingArray extends MappingBaseType {
   }
 
   get resolvedResult() {
-    const result = this.createResult();
+    let result = this.createResult();
+
+    if (result.type == 'object') {
+      let parent_name = this.resolveFirstItem.key
+      let properties = this.resolveFirstItem.properties
+      result.properties = propsToMapping({ parent_name, properties}, this.config)
+    }
+
     if (this.isReference) {
       delete result.type
     };
@@ -26,7 +34,7 @@ class MappingArray extends MappingBaseType {
   }
 
   get includeInParent() {
-    return true;
+    return false;
   }
 
   get resolvedEntry() {

--- a/src/types/number.js
+++ b/src/types/number.js
@@ -136,7 +136,8 @@ class MappingNumber extends MappingRange {
 
   get numericFormat() {
     return {
-      integer: "integer"
+      integer: "integer",
+      int64: "long"
     };
   }
 


### PR DESCRIPTION
For posterity:

I say monkey-patch because `type: integer, format: int64` is not officially supported JSON-schema and the error likely is really with the schema we present. That said, this patch is ready and will not make the API and more incorrect since the ElasticSearch the improper JSONschema is converted to is correct.

In the future I would like to follow the unofficial expanded formats specified by Google's API discovery service [here](https://developers.google.com/discovery/v1/type-format). Because in implementation nearly every JSON library interprets JSON `number` as a double so it would be capped at 2^52 which would make it unwise to send and return 64bit integers as JSON numbers. The proposed solution is to send them as strings with an int64 format (i.e `type: string, format: int64`)